### PR TITLE
Using php-7.4 version directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     env: setup=lowest
   - php: '7.3'
     env: coverage=true
-  - php: 7.4snapshot
+  - php: '7.4'
     env: setup=lowest
-  - php: 7.4snapshot
+  - php: '7.4'
   - php: '7.3'
     env: style=true
 
@@ -31,8 +31,8 @@ before_script:
 - if [[ $style = 'true' ]]; then pecl install ast; fi
 
 install:
-- if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --dev; fi
-- if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --dev; fi
+- if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction; fi
+- if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest; fi
 
 script:
 - if [[ $style != 'true' && $coverage != 'true' ]]; then composer phpunit; fi


### PR DESCRIPTION
# Changed log
- Since the `php-7.4` is available on Travis CI build, using the `php-7.4` instead.
- The `--dev` option on `composer install` is deprecated.
The deprecated message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```