### PR TITLE
Add do() and doNow() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ echo Carbon::now()->isoFormat('h:mm:ssa'); // output: 8:02:01pm
 Carbonite::jumpTo('19 October 1977 11:00:00pm');
 Carbonite::speed(3600); // and it's like every second was an hour
 // 4 seconds later, now it's 19 October 1977 11:00:04pm
-// it's like it's alreay 3am the next day
+// it's like it's already 3am the next day
 echo Carbon::now()->isoFormat('YYYY-MM-DD h:mm:ssa'); // output: 1977-10-20 3:00:00am
 ```
 
@@ -275,7 +275,9 @@ A second parameter can be passed to change the speed after the jump. By default,
 `do($moment, callable $action)`
 
 Trigger a given $action in a frozen instant $testNow. And restore previous moment and
-     * speed once it's done, rather it succeeded or threw an error or an exception.
+speed once it's done, rather it succeeded or threw an error or an exception.
+
+Returns the value returned by the given $action.
 
 ```php
 Carbonite::freeze('2000-01-01', 1.5);
@@ -291,7 +293,39 @@ echo Carbon::now()->format('Y-m-d'); // output: 2000-01-01
 echo Carbonite::speed(); // output: 1.5
 ```
 
-A second parameter can be passed to change the speed after the jump. By default, speed is not changed.
+`Carbonite::do()` is a good way to isolate a test and use a particular date
+as "now" then be sure to restore the previous state. If there is no previous
+Carbonite state (if you didn't do any freeze, jump, speed, etc.) then `Carbon::now()`
+will just no longer be mocked at all.
+
+### doNow
+
+`doNow(callable $action)`
+
+Trigger a given $action in the frozen current instant. And restore previous
+speed once it's done, rather it succeeded or threw an error or an exception.
+
+Returns the value returned by the given $action.
+
+```php
+// Assuming now is 17 September 2020 8pm
+Carbonite::doNow(static function () {
+    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-09-17 20:00:00.000000
+    usleep(200);
+    // Still the same output as time is frozen inside the callback
+    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-09-17 20:00:00.000000
+echo Carbonite::speed(); // output: 0
+});
+// Now the speed is 1 again
+echo Carbonite::speed(); // output: 1
+```
+
+It's actually a shortcut for `Carbonite::do('now', callable $action)`.
+
+`Carbonite::doNow()` is a good way to isolate a test, stop the time for this test
+then be sure to restore the previous state. If there is no previous
+Carbonite state (if you didn't do any freeze, jump, speed, etc.) then `Carbon::now()`
+will just no longer be mocked at all.
 
 ### release
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,27 @@ echo Carbon::now()->format('Y-m-d'); // output: 1998-10-29
 
 A second parameter can be passed to change the speed after the jump. By default, speed is not changed.
 
+### do
+
+`do($moment, callable $action)`
+
+Trigger a given $action in a frozen instant $testNow. And restore previous moment and
+     * speed once it's done, rather it succeeded or threw an error or an exception.
+
+```php
+Carbonite::freeze('2000-01-01', 1.5);
+Carbonite::do('2020-12-23', static function () {
+    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-12-23 00:00:00.000000
+    usleep(200);
+    // Still the same output as time is frozen inside the callback
+    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-12-23 00:00:00.000000
+});
+// Now the speed is 1.5 on 2000-01-01 again
+echo Carbon::now()->format('Y-m-d'); // output: 2000-01-01
+```
+
+A second parameter can be passed to change the speed after the jump. By default, speed is not changed.
+
 ### release
 
 `release(): void`

--- a/README.md
+++ b/README.md
@@ -284,9 +284,11 @@ Carbonite::do('2020-12-23', static function () {
     usleep(200);
     // Still the same output as time is frozen inside the callback
     echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-12-23 00:00:00.000000
+echo Carbonite::speed(); // output: 0
 });
 // Now the speed is 1.5 on 2000-01-01 again
 echo Carbon::now()->format('Y-m-d'); // output: 2000-01-01
+echo Carbonite::speed(); // output: 1.5
 ```
 
 A second parameter can be passed to change the speed after the jump. By default, speed is not changed.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
       "@phpcs",
       "@phpcsf",
       "@phpstan",
-      "@phpmd",
       "@psalm",
       "@phan"
     ],

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "phpstan/phpstan": "^0.11.0",
     "phpunit/phpunit": "^8.3.2",
     "squizlabs/php_codesniffer": "^3.0",
-    "vimeo/psalm": "^3.0@dev",
-    "povils/phpmnd": "^2.3@dev"
+    "vimeo/psalm": "^3.0@dev"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "phpstan/phpstan": "^0.11.0",
     "phpunit/phpunit": "^8.3.2",
     "squizlabs/php_codesniffer": "^3.0",
-    "vimeo/psalm": "^3.0@dev"
+    "vimeo/psalm": "^3.0@dev",
+    "povils/phpmnd": "^2.3@dev"
   },
   "autoload": {
     "psr-4": {

--- a/src/Carbon/Carbonite.php
+++ b/src/Carbon/Carbonite.php
@@ -165,8 +165,8 @@ class Carbonite
      *
      * Returns the value returned by the given $action.
      *
-     * @param string|CarbonInterface|Closure|null $testNow
-     * @param callable                            $action
+     * @param string|CarbonInterface|CarbonPeriod|CarbonInterval|DateTimeInterface|DatePeriod|DateInterval $testNow
+     * @param callable                                                                                     $action
      *
      * @return mixed
      */
@@ -181,8 +181,7 @@ class Carbonite
      *
      * Returns the value returned by the given $action.
      *
-     * @param string|CarbonInterface|Closure|null $testNow
-     * @param callable                            $action
+     * @param callable $action
      *
      * @return mixed
      */

--- a/src/Carbon/Carbonite.php
+++ b/src/Carbon/Carbonite.php
@@ -160,6 +160,38 @@ class Carbonite
     }
 
     /**
+     * Trigger a given $action in a frozen instant $testNow. And restore previous moment and
+     * speed once it's done, rather it succeeded or threw an error or an exception.
+     *
+     * Returns the value returned by the given $action.
+     *
+     * @param string|CarbonInterface|Closure|null $testNow
+     * @param callable                            $action
+     *
+     * @return mixed
+     */
+    public static function do($testNow, callable $action)
+    {
+        return self::tibanna()->do($testNow, $action);
+    }
+
+    /**
+     * Trigger a given $action in the frozen current instant. And restore previous
+     * speed once it's done, rather it succeeded or threw an error or an exception.
+     *
+     * Returns the value returned by the given $action.
+     *
+     * @param string|CarbonInterface|Closure|null $testNow
+     * @param callable                            $action
+     *
+     * @return mixed
+     */
+    public static function doNow(callable $action)
+    {
+        return self::tibanna()->do('now', $action);
+    }
+
+    /**
      * Set the "real" now moment, it's a mock inception. It means that when you call release()
      * You will no longer go back to present but you will fallback to the mocked now. And the
      * mocked now will also determine the base speed to consider. If this mocked instance is

--- a/src/Carbon/Carbonite/Tibanna.php
+++ b/src/Carbon/Carbonite/Tibanna.php
@@ -260,7 +260,11 @@ class Tibanna
         $throwable = null;
         $result = null;
         $initialSpeed = $this->speed;
-        $initialTestNow = Carbon::getTestNow();
+        $initialMutableTestNow = Carbon::getTestNow();
+        $initialImmutableTestNow = CarbonImmutable::getTestNow();
+        $initialTestNow = $this->testNow;
+        $initialMoment = $this->moment;
+        $initialFrozenAt = $this->lastFrozenAt;
         $this->freeze($testNow, 0);
 
         try {
@@ -269,8 +273,12 @@ class Tibanna
             $throwable = $error;
         }
 
-        $this->speed($initialSpeed);
-        $this->setTestNow($initialTestNow);
+        $this->speed = $initialSpeed;
+        $this->testNow = $initialTestNow;
+        $this->moment = $initialMoment;
+        $this->lastFrozenAt = $initialFrozenAt;
+        Carbon::setTestNow($initialMutableTestNow);
+        CarbonImmutable::setTestNow($initialImmutableTestNow);
 
         if ($throwable) {
             throw $throwable;
@@ -280,19 +288,17 @@ class Tibanna
     }
 
     /**
-     * Set a Carbon and CarbonImmutable instance (real or mock) to be returned when a "now"
-     * instance is created.  The provided instance will be returned
-     * specifically under the following conditions:
+     * Set a Carbon and CarbonImmutable instance (real or mock) to be returned when a "now" instance
+     * is created. The provided instance will be returned specifically under the following conditions:
      *   - A call to the static now() method, ex. Carbon::now()
      *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Carbon(null)
      *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
      *   - When a string containing the desired time is passed to Carbon::parse().
      *
-     * Note the timezone parameter was left out of the examples above and
-     * has no affect as the mock value will be returned regardless of its value.
+     * Note the timezone parameter was left out of the examples above and has no affect as the mock
+     * value will be returned regardless of its value.
      *
-     * To clear the test instance call this method using the default
-     * parameter of null.
+     * To clear the test instance call this method using the default parameter of null.
      *
      * /!\ Use this method for unit tests only.
      *

--- a/src/Carbon/Carbonite/Tibanna.php
+++ b/src/Carbon/Carbonite/Tibanna.php
@@ -250,8 +250,8 @@ class Tibanna
      *
      * Returns the value returned by the given $action.
      *
-     * @param string|CarbonInterface|Closure|null $testNow
-     * @param callable                            $action
+     * @param string|CarbonInterface|CarbonPeriod|CarbonInterval|DateTimeInterface|DatePeriod|DateInterval $testNow
+     * @param callable                                                                                     $action
      *
      * @return mixed
      */
@@ -302,7 +302,7 @@ class Tibanna
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param static|string|null $testNow real or mock Carbon instance
+     * @param Closure|CarbonInterface|string|null $testNow real or mock Carbon instance
      */
     protected function setTestNow($testNow = null)
     {

--- a/tests/Carbon/CarboniteTest.php
+++ b/tests/Carbon/CarboniteTest.php
@@ -8,6 +8,7 @@ use Carbon\Carbonite\UnfrozenTimeException;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -84,6 +85,7 @@ class CarboniteTest extends TestCase
     /**
      * @covers ::freeze
      * @covers \Carbon\Carbonite\Tibanna::freeze
+     * @covers \Carbon\Carbonite\Tibanna::setTestNow
      */
     public function testFreeze(): void
     {
@@ -416,6 +418,32 @@ class CarboniteTest extends TestCase
 
         self::assertFalse(Carbon::hasTestNow());
         self::assertSame(1.0, Carbonite::speed());
+        self::assertLessThan(500, Carbon::now()->diffInMicroseconds(new DateTime()));
+    }
+
+    /**
+     * @covers ::do
+     * @covers \Carbon\Carbonite\Tibanna::do
+     */
+    public function testDoWithError(): void
+    {
+        $date = null;
+        $message = null;
+
+        try {
+            Carbonite::do('2019-08-24', static function () use (&$date) {
+                $date = Carbon::now();
+
+                throw new Exception('stop');
+            });
+
+            $date = 'erased';
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+
+        self::assertSame('2019-08-24', $date->format('Y-m-d'));
+        self::assertSame('stop', $message);
         self::assertLessThan(500, Carbon::now()->diffInMicroseconds(new DateTime()));
     }
 

--- a/tests/Carbon/CarboniteTest.php
+++ b/tests/Carbon/CarboniteTest.php
@@ -432,7 +432,7 @@ class CarboniteTest extends TestCase
 
         try {
             Carbonite::do('2019-08-24', static function () use (&$date) {
-                $date = Carbon::now();
+                $date = Carbon::now()->format('Y-m-d');
 
                 throw new Exception('stop');
             });
@@ -442,7 +442,7 @@ class CarboniteTest extends TestCase
             $message = $e->getMessage();
         }
 
-        self::assertSame('2019-08-24', $date->format('Y-m-d'));
+        self::assertSame('2019-08-24', $date);
         self::assertSame('stop', $message);
         self::assertLessThan(500, Carbon::now()->diffInMicroseconds(new DateTime()));
     }

--- a/tests/Carbon/CarboniteTest.php
+++ b/tests/Carbon/CarboniteTest.php
@@ -421,7 +421,7 @@ class CarboniteTest extends TestCase
 
     /**
      * @covers ::doNow
-     * @covers \Carbon\Carbonite\Tibanna::doNow
+     * @covers \Carbon\Carbonite\Tibanna::do
      */
     public function testDoNow(): void
     {


### PR DESCRIPTION
### do

`do($moment, callable $action)`

Trigger a given $action in a frozen instant $testNow. And restore previous moment and
speed once it's done, rather it succeeded or threw an error or an exception.

Returns the value returned by the given $action.

```php
Carbonite::freeze('2000-01-01', 1.5);
Carbonite::do('2020-12-23', static function () {
    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-12-23 00:00:00.000000
    usleep(200);
    // Still the same output as time is frozen inside the callback
    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-12-23 00:00:00.000000
echo Carbonite::speed(); // output: 0
});
// Now the speed is 1.5 on 2000-01-01 again
echo Carbon::now()->format('Y-m-d'); // output: 2000-01-01
echo Carbonite::speed(); // output: 1.5
```

`Carbonite::do()` is a good way to isolate a test and use a particular date
as "now" then be sure to restore the previous state. If there is no previous
Carbonite state (if you didn't do any freeze, jump, speed, etc.) then `Carbon::now()`
will just no longer be mocked at all.

### doNow

`doNow(callable $action)`

Trigger a given $action in the frozen current instant. And restore previous
speed once it's done, rather it succeeded or threw an error or an exception.

Returns the value returned by the given $action.

```php
// Assuming now is 17 September 2020 8pm
Carbonite::doNow(static function () {
    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-09-17 20:00:00.000000
    usleep(200);
    // Still the same output as time is frozen inside the callback
    echo Carbon::now()->format('Y-m-d H:i:s.u'); // output: 2020-09-17 20:00:00.000000
echo Carbonite::speed(); // output: 0
});
// Now the speed is 1 again
echo Carbonite::speed(); // output: 1
```

It's actually a shortcut for `Carbonite::do('now', callable $action)`.

`Carbonite::doNow()` is a good way to isolate a test, stop the time for this test
then be sure to restore the previous state. If there is no previous
Carbonite state (if you didn't do any freeze, jump, speed, etc.) then `Carbon::now()`
will just no longer be mocked at all.